### PR TITLE
Error when hiding menu on back navigation Android

### DIFF
--- a/SlideOverKit.Droid/MenuContainerPageDroidRenderer.cs
+++ b/SlideOverKit.Droid/MenuContainerPageDroidRenderer.cs
@@ -16,6 +16,8 @@ namespace SlideOverKit.Droid
 
         public Action<int,int,int,int> OnSizeChangedEvent { get; set; }
 
+        public bool IsDisposed { get; set; }
+
         public MenuContainerPageDroidRenderer ()
         {
             new SlideOverKitDroidHandler ().Init (this);

--- a/SlideOverKit.Droid/SlideOverKitDroidHandler.cs
+++ b/SlideOverKit.Droid/SlideOverKitDroidHandler.cs
@@ -203,6 +203,8 @@ namespace SlideOverKit.Droid
         void HideBackgroundOverlay ()
         {
             if (_backgroundOverlay != null) {
+                var renderer = _pageRenderer as MenuContainerPageDroidRenderer;
+                if (renderer == null || !renderer.IsDisposed) _pageRenderer.RemoveView(_backgroundOverlay);
                 _pageRenderer.RemoveView (_backgroundOverlay);
                 _backgroundOverlay.Dispose ();
                 _backgroundOverlay = null;


### PR DESCRIPTION
On Xamarin.Forms (Droid) a "Cannot access a disposed object" exception is thrown when we call HideMenu in OnDisappearing() in a Page thats on a navigation stack.

We are currently using this package in a project with planned release around Christmas.