### PR TITLE
Fix for ObjectDisposedException on Android

### DIFF
--- a/SlideOverKit.Droid/SlideOverKitDroidHandler.cs
+++ b/SlideOverKit.Droid/SlideOverKitDroidHandler.cs
@@ -202,10 +202,20 @@ namespace SlideOverKit.Droid
 
         void HideBackgroundOverlay ()
         {
-            if (_backgroundOverlay != null) {
-                _pageRenderer.RemoveView (_backgroundOverlay);
-                _backgroundOverlay.Dispose ();
+            try
+            {
+                if (_backgroundOverlay != null)
+                {
+                    _pageRenderer.RemoveView(_backgroundOverlay);
+                    _backgroundOverlay.Dispose();
+                    _backgroundOverlay = null;
+                }
+            }
+            catch(ObjectDisposedException)
+            {
+                // On Android, _backgroundOverlay was not null but HAD been disposed. Attempting to remove it caused an ObjectDisposedException
                 _backgroundOverlay = null;
+                // Swallow this - let anything else cause a problem
             }
         }
 


### PR DESCRIPTION
I was getting an ObjectDisposedException on Android when using SlideOverKit for root level navigation.
![slideoverkiterror](https://user-images.githubusercontent.com/6386828/39558473-3e86e572-4ed2-11e8-8bfb-ca5cf4e74ad3.png)
