### PR TITLE
Check for visual element when determining popup margin

### DIFF
--- a/SlideOverKit/SlidePopupView.cs
+++ b/SlideOverKit/SlidePopupView.cs
@@ -97,8 +97,10 @@ namespace SlideOverKit
                         LeftMargin -= (parent as ScrollView).ScrollX;
                         TopMargin -= (parent as ScrollView).ScrollY;
                     }
-                    LeftMargin += (parent as VisualElement).X;
-                    TopMargin += (parent as VisualElement).Y;
+                    if (parent is VisualElement) {
+                        LeftMargin += (parent as VisualElement).X;
+                        TopMargin += (parent as VisualElement).Y;
+                    }
                     parent = parent.Parent;
                 }
             }


### PR DESCRIPTION
When a popup with targetcontrol is shown, it determines position by traversing each parent, however it does not check to see if the parent is a VisualElement which causes an exception in cases such as a ViewCell which is not a VisualElement.